### PR TITLE
Version 3 - Simplified Fluent Interface

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,15 @@
+env:
+  global:
+    - CC_TEST_REPORTER_ID=c14dfc2c8a10a029ac3706d2c2c86f63f663a1445df6213e013a42cbc9a55e74
 language: ruby
 rvm:
   - 2.3.0
 before_install: gem install bundler -v 1.12.5
+before_script:
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
+script:
+  - rake test
+after_script:
+  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Build Status](https://travis-ci.org/PokemonTCG/pokemon-tcg-sdk-ruby.svg?branch=master)](https://travis-ci.org/PokemonTCG/pokemon-tcg-sdk-ruby)
 [![Dependency Status](https://gemnasium.com/badges/github.com/PokemonTCG/pokemon-tcg-sdk-ruby.svg)](https://gemnasium.com/github.com/PokemonTCG/pokemon-tcg-sdk-ruby)
 [![Code Climate](https://codeclimate.com/github/PokemonTCG/pokemon-tcg-sdk-ruby/badges/gpa.svg)](https://codeclimate.com/github/PokemonTCG/pokemon-tcg-sdk-ruby)
-[![Coverage Status](https://coveralls.io/repos/github/PokemonTCG/pokemon-tcg-sdk-ruby/badge.svg?branch=master)](https://coveralls.io/github/PokemonTCG/pokemon-tcg-sdk-ruby?branch=master)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/ee9d7d6ee5f8276729bc/test_coverage)](https://codeclimate.com/github/PokemonTCG/pokemon-tcg-sdk-ruby/test_coverage)
 
 This is the Pokémon TCG SDK Ruby implementation. It is a wrapper around the Pokémon TCG API of [pokemontcg.io](http://pokemontcg.io/).
 
@@ -63,6 +63,7 @@ To change the API version (currently defaults to version 1)
     set
     set_code
     retreat_cost
+    converted_retreat_cost
     text
     types
     attacks
@@ -112,7 +113,7 @@ To change the API version (currently defaults to version 1)
 
 #### Filter Cards via query parameters
 
-    cards = Pokemon::Card.where(set: 'generations').where(supertype: 'pokemon').all
+    cards = Pokemon::Card.where(set: 'generations', supertype: 'pokemon')
     
 #### Find all cards (will take awhile)
 
@@ -120,7 +121,7 @@ To change the API version (currently defaults to version 1)
     
 #### Get all cards, but only a specific page of data
 
-    cards = Pokemon::Card.where(page: 5).where(pageSize: 100).all
+    cards = Pokemon::Card.where(page: 5, pageSize: 100)
     
 #### Find a set by code
 
@@ -128,7 +129,7 @@ To change the API version (currently defaults to version 1)
     
 #### Filter sets via query parameters
 
-    sets = Pokemon::Set.where(standardLegal: true).all
+    sets = Pokemon::Set.where(standardLegal: true)
     
 #### Get all Sets
 

--- a/README.md
+++ b/README.md
@@ -77,9 +77,12 @@ To change the API version (currently defaults to version 1)
     name
     series
     total_cards
+    symbol_url
+    logo_url
     standard_legal
     expanded_legal
     release_date
+    updated_at
 
 #### Ability
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,10 @@
 require "bundler/gem_tasks"
 require 'rake/testtask'
-require_relative 'lib/pokemon_tcg_sdk'
 
 task :default => :test
 
 Rake::TestTask.new do |t|
+  t.libs << "lib"
   t.libs << "test"
   t.test_files = FileList['test/*_test.rb']
   t.verbose = true

--- a/lib/pokemon_tcg_sdk/card.rb
+++ b/lib/pokemon_tcg_sdk/card.rb
@@ -35,7 +35,7 @@ module Pokemon
     # Adds a parameter to the hash of query parameters
     #
     # @param args [Hash] the query parameter
-    # @return [QueryBuilder] the QueryBuilder
+    # @return [Array<Card>] Array of Card objects
     def self.where(args)
       QueryBuilder.new(Card).where(args)
     end

--- a/lib/pokemon_tcg_sdk/card.rb
+++ b/lib/pokemon_tcg_sdk/card.rb
@@ -8,7 +8,7 @@ module Pokemon
     attr_accessor :id, :name, :image_url, :image_url_hi_res, :subtype, :supertype, :ability,
                   :hp, :number, :artist, :rarity, :series, :set, :set_code,
                   :retreat_cost, :text, :types, :attacks, :weaknesses, :resistances,
-                  :national_pokedex_number, :ancient_trait, :evolves_from
+                  :national_pokedex_number, :ancient_trait, :evolves_from, :converted_retreat_cost
 
     # Get the resource string
     #

--- a/lib/pokemon_tcg_sdk/query_builder.rb
+++ b/lib/pokemon_tcg_sdk/query_builder.rb
@@ -16,7 +16,7 @@ module Pokemon
     # @return [QueryBuilder] the QueryBuilder
     def where(args)
       @query.merge!(args)
-      self
+      self.all
     end
     
     # Find a single resource by the resource id

--- a/lib/pokemon_tcg_sdk/representers/card_representer.rb
+++ b/lib/pokemon_tcg_sdk/representers/card_representer.rb
@@ -29,6 +29,7 @@ module Pokemon
     property :set_code, as: :setCode
     property :national_pokedex_number, as: :nationalPokedexNumber
     property :evolves_from, as: :evolvesFrom
+    property :converted_retreat_cost, as: :convertedRetreatCost
     
     collection :retreat_cost, as: :retreatCost
     collection :text

--- a/lib/pokemon_tcg_sdk/representers/set_representer.rb
+++ b/lib/pokemon_tcg_sdk/representers/set_representer.rb
@@ -9,9 +9,11 @@ module Pokemon
     property :series
     property :ptcgo_code, as: :ptcgoCode
     property :symbol_url, as: :symbolUrl
+    property :logo_url, as: :logoUrl
     property :total_cards, as: :totalCards
     property :standard_legal, as: :standardLegal
     property :expanded_legal, as: :expandedLegal
     property :release_date, as: :releaseDate
+    property :updated_at, as: :updatedAt
   end
 end

--- a/lib/pokemon_tcg_sdk/set.rb
+++ b/lib/pokemon_tcg_sdk/set.rb
@@ -6,7 +6,7 @@ module Pokemon
     include SetRepresenter
 
     attr_accessor :code, :name, :series, :total_cards, :standard_legal, :expanded_legal, :release_date,
-                  :symbol_url, :ptcgo_code
+                  :symbol_url, :logo_url, :ptcgo_code, :updated_at
 
     # Get the resource string
     #

--- a/lib/pokemon_tcg_sdk/set.rb
+++ b/lib/pokemon_tcg_sdk/set.rb
@@ -33,7 +33,7 @@ module Pokemon
     # Adds a parameter to the hash of query parameters
     #
     # @param args [Hash] the query parameter
-    # @return [QueryBuilder] the QueryBuilder
+    # @return [Array<Set>] Array of Set objects
     def self.where(args)
       QueryBuilder.new(Set).where(args)
     end

--- a/lib/pokemon_tcg_sdk/version.rb
+++ b/lib/pokemon_tcg_sdk/version.rb
@@ -1,3 +1,3 @@
 module Pokemon
-  VERSION = "2.5.0"
+  VERSION = "3.0.0"
 end

--- a/pokemon_tcg_sdk.gemspec
+++ b/pokemon_tcg_sdk.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "vcr", "~> 3.0"
   spec.add_development_dependency "webmock", "~> 2.1"
   spec.add_development_dependency "simplecov", "~> 0.14"
-  spec.add_development_dependency "coveralls", "0.8.21"
   spec.add_development_dependency "codeclimate-test-reporter", "~> 0.6"
 
   spec.add_dependency "roar", "~> 1.0"

--- a/test/card_test.rb
+++ b/test/card_test.rb
@@ -1,5 +1,5 @@
 # encoding: UTF-8
-require_relative 'test_helper'
+require 'test_helper'
 
 class CardTest < Minitest::Test
   def test_find_returns_one_card
@@ -18,6 +18,7 @@ class CardTest < Minitest::Test
       assert_equal 'Ability', card.ability.type
       assert_equal "170", card.hp
       assert_equal ["Colorless","Colorless","Colorless"], card.retreat_cost
+      assert_equal 3, card.converted_retreat_cost
       assert_equal "57", card.number
       assert_equal "PLANETA", card.artist
       assert_equal "Rare Holo EX", card.rarity
@@ -46,7 +47,7 @@ class CardTest < Minitest::Test
   
   def test_where_with_page_size_and_page_returns_cards
     VCR.use_cassette('query_cards_pageSize') do
-      cards = Pokemon::Card.where(pageSize: 10).where(page: 1).all
+      cards = Pokemon::Card.where(pageSize: 10, page: 1)
 
       # make sure we got only 10 cards back
       assert cards.length == 10
@@ -57,10 +58,7 @@ class CardTest < Minitest::Test
 
   def test_all_returns_cards
     VCR.use_cassette('all_filtered') do
-      cards = Pokemon::Card.where(supertype: 'pokemon')
-                       .where(subtype: 'basic')
-                       .where(set: 'generations')
-                       .all
+      cards = Pokemon::Card.where(supertype: 'pokemon', subtype: 'basic', set: 'generations')
 
       card = cards[0]
       assert_equal 'Pokémon', card.supertype

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -1,5 +1,4 @@
-#test/client_test.rb
-require_relative 'test_helper'
+require 'test_helper'
 
 class ConfigurationTest < Minitest::Test
   def test_defaults

--- a/test/set_test.rb
+++ b/test/set_test.rb
@@ -13,6 +13,7 @@ class SetTest < Minitest::Test
       assert_equal true, set.expanded_legal
       assert_equal "02/22/2016", set.release_date
       assert_equal "https://images.pokemontcg.io/g1/symbol.png", set.symbol_url
+      assert_equal "https://images.pokemontcg.io/g1/logo.png", set.logo_url
       assert_equal 'GEN', set.ptcgo_code
     end
   end

--- a/test/set_test.rb
+++ b/test/set_test.rb
@@ -35,7 +35,7 @@ class SetTest < Minitest::Test
   
   def test_where_filters_on_cards
     VCR.use_cassette('filtered_sets') do
-      sets = Pokemon::Set.where(standardLegal: true).all
+      sets = Pokemon::Set.where(standardLegal: true)
       
       assert_equal true, sets[0].standard_legal
     end

--- a/test/subtype_test.rb
+++ b/test/subtype_test.rb
@@ -1,4 +1,4 @@
-require_relative 'test_helper'
+require 'test_helper'
 
 class SubtypeTest < Minitest::Test
   def test_all_returns_all_subtypes

--- a/test/supertype_test.rb
+++ b/test/supertype_test.rb
@@ -1,4 +1,4 @@
-require_relative 'test_helper'
+require 'test_helper'
 
 class SupertypeTest < Minitest::Test
   def test_all_returns_all_types

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,16 +1,14 @@
 #test/test_helper.rb
 require 'simplecov'
-require 'coveralls'
 require 'codeclimate-test-reporter'
 
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
   SimpleCov::Formatter::HTMLFormatter,
-  Coveralls::SimpleCov::Formatter,
   CodeClimate::TestReporter::Formatter
 ])
 SimpleCov.start
 
-require_relative '../lib/pokemon_tcg_sdk'
+require 'pokemon_tcg_sdk'
 require 'minitest/autorun'
 require 'webmock/minitest'
 require 'vcr'

--- a/test/type_test.rb
+++ b/test/type_test.rb
@@ -1,4 +1,4 @@
-require_relative 'test_helper'
+require 'test_helper'
 
 class TypeTest < Minitest::Test
   def test_all_returns_all_types


### PR DESCRIPTION
This has breaking changes. `where` clauses are no longer chained together in favor of a single `where` clause that takes a hash. There is no need to call `all` after the `where`.

Example:

V2:
`Card.where(supertype: 'pokemon').where(types: 'psychic).all`

[NEW] V3
`Card.where(supertype: 'pokemon', types: 'psychic')`