### PR TITLE
Update to Faraday v2

### DIFF
--- a/lib/pokemon_tcg_sdk/rest_client.rb
+++ b/lib/pokemon_tcg_sdk/rest_client.rb
@@ -1,5 +1,4 @@
 require 'faraday'
-require 'faraday_middleware'
 require 'erb'
 
 module Pokemon
@@ -27,9 +26,9 @@ module Pokemon
         raise 'Something went wrong...please try again later.'
       end
     end
-    
+
     protected
-    
+
     def self.client
       headers = {'Content-Type' => 'application/json'}
       headers['X-Api-Key'] = Pokemon.configuration.api_key unless Pokemon.configuration.api_key.nil?

--- a/pokemon_tcg_sdk.gemspec
+++ b/pokemon_tcg_sdk.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 2.2.11"
+  spec.add_development_dependency "bundler", "~> 2.2"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "minitest", "~> 5.14.2"
   spec.add_development_dependency "vcr", "~> 6.0"
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "json", "~> 2.3"
   spec.add_dependency "multi_json", "~> 1.15"
   spec.add_dependency "multi_xml", "~> 0.6"
-  spec.add_dependency "faraday_middleware", "~> 1.0"
+  spec.add_dependency "faraday", "~> 2.0"
 end


### PR DESCRIPTION
faraday_middleware is deprecated, and the functionality built into it is now part of Faraday itself. (My next planned step is the ability to add Faraday middleware in the `Pokemon.configuration` block, specifically to be able to add caching middleware.)